### PR TITLE
removed content-type for multipart/form-data

### DIFF
--- a/assets/scripts/lib/EasyAjax.js
+++ b/assets/scripts/lib/EasyAjax.js
@@ -127,6 +127,8 @@ define(["JS"], function(JS) {
         if (_method === "POST" && !this.getRequestHeader("Content-Type")) {
           this.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
           this.setRequestHeader("Content-Type", "charset=UTF-8");
+        } else if (this.getRequestHeader("Content-Type").indexOf("multipart/form-data") !== -1) {
+          delete _requestHeader["Content-Type"];
         }
         for (var header in _requestHeader) {
           if (_requestHeader.hasOwnProperty(header)

--- a/assets/scripts/lib/EasyAjax.js
+++ b/assets/scripts/lib/EasyAjax.js
@@ -124,11 +124,15 @@ define(["JS"], function(JS) {
        * Triggers Request to send
        */
       send: function() {
-        if (_method === "POST" && !this.getRequestHeader("Content-Type")) {
-          this.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-          this.setRequestHeader("Content-Type", "charset=UTF-8");
-        } else if (this.getRequestHeader("Content-Type").indexOf("multipart/form-data") !== -1) {
-          delete _requestHeader["Content-Type"];
+        if (_method === "POST") {
+            var _contentType = this.getRequestHeader("Content-Type");
+            if (!_contentType) {
+                this.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+                this.setRequestHeader("Content-Type", "charset=UTF-8");
+            }
+            if (!!_contentType && _contentType.indexOf("multipart/form-data") !== -1) {
+                delete _requestHeader["Content-Type"];
+            }
         }
         for (var header in _requestHeader) {
           if (_requestHeader.hasOwnProperty(header)


### PR DESCRIPTION
When uploading files via Ajax and FormData, you must not set the `Content-Type: multipart/form-data` header. This will cause the browser to really send a header Content-Type: multipart/form-data which is wrong. If you do not set this header explicitely it will set the header to something like Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryhwk47FtsDeemWl3V. So basically the boundary is missing which makes it impossible for the server side to parse the body.